### PR TITLE
Fix update existing key

### DIFF
--- a/lib/src/lru_cache.dart
+++ b/lib/src/lru_cache.dart
@@ -4,9 +4,8 @@ import 'package:meta/meta.dart';
 
 import 'lru_cache_entry.dart';
 
-
 /// Cache implementation based on least recently used eviction strategy.
-/// 
+///
 /// {@template lru_cache_docs}
 /// Elements are stored in [Map] and expected to have a constant (worst-case
 /// linear for bad [Object.hashCode]) access time.
@@ -14,9 +13,10 @@ import 'lru_cache_entry.dart';
 /// {@endtemplate}
 base class LruCache<K, V extends Object> with MapBase<K, V> {
   /// Create new LRU cache with [capacity].
-  /// 
+  ///
   /// {@macro lru_cache_docs}
-  LruCache(this.capacity) : assert(capacity >= 0, 'Capacity must not be negative');
+  LruCache(this.capacity)
+      : assert(capacity >= 0, 'Capacity must not be negative');
 
   /// Maximum capacity of this cache.
   final int capacity;
@@ -37,19 +37,16 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
   /// Subclasses should not pass unrelated to [list] entries.
   @protected
   void touchListEntry(LruCacheEntry<K, V> entry) {
-    if (entry == list.firstOrNull)
-      return;
-    if (entry.list != null)
-      entry.unlink();
+    if (entry == list.firstOrNull) return;
+    if (entry.list != null) entry.unlink();
     list.addFirst(entry);
-    if (list.length > capacity)
-      evictListEntry(list.last);
+    if (list.length > capacity) evictListEntry(list.last);
   }
 
   /// Removes [entry] from linked [list] and [cache] map.
   @protected
   LruCacheEntry<K, V>? evictListEntry(LruCacheEntry<K, V> entry) =>
-    cache.remove(entry.key)?..unlink();
+      cache.remove(entry.key)?..unlink();
 
   // MapBase required methods
 
@@ -64,13 +61,15 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
 
   @override
   void operator []=(K key, V value) {
+    if (cache.containsKey(key)) {
+      remove(key);
+    }
     final entry = cache[key] = LruCacheEntry(key, value);
     touchListEntry(entry);
   }
 
   @override
-  V? remove(Object? key) =>
-    (cache.remove(key)?..unlink())?.value;
+  V? remove(Object? key) => (cache.remove(key)?..unlink())?.value;
 
   @override
   void clear() {
@@ -80,15 +79,13 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
 
   // MapBase performance overrides and fixes that ensures no LRU updates on
   // contains checks.
- 
+
   @override
   bool containsKey(Object? key) => cache.containsKey(key);
 
   @override
   bool containsValue(Object? value) {
-    for (final entry in cache.values)
-      if (entry.value == value)
-        return true;
+    for (final entry in cache.values) if (entry.value == value) return true;
     return false;
   }
 

--- a/lib/src/lru_cache.dart
+++ b/lib/src/lru_cache.dart
@@ -15,18 +15,19 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
   /// Create new LRU cache with [capacity].
   ///
   /// {@macro lru_cache_docs}
-  LruCache(this.capacity)
-      : assert(capacity >= 0, 'Capacity must not be negative');
+  LruCache(this.capacity) : assert(capacity >= 0, 'Capacity must not be negative');
 
   /// Maximum capacity of this cache.
   final int capacity;
 
   /// Map used for quick access to cache entries.
   @protected
+  @visibleForTesting
   final cache = <K, LruCacheEntry<K, V>>{};
 
   /// Linked list used to keep track of access order of cache entries.
   @protected
+  @visibleForTesting
   final list = LinkedList<LruCacheEntry<K, V>>();
 
   /// Moves entry to top of linked [list].
@@ -37,16 +38,19 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
   /// Subclasses should not pass unrelated to [list] entries.
   @protected
   void touchListEntry(LruCacheEntry<K, V> entry) {
-    if (entry == list.firstOrNull) return;
-    if (entry.list != null) entry.unlink();
+    if (entry == list.firstOrNull)
+      return;
+    if (entry.list != null)
+      entry.unlink();
     list.addFirst(entry);
-    if (list.length > capacity) evictListEntry(list.last);
+    if (list.length > capacity)
+      evictListEntry(list.last);
   }
 
   /// Removes [entry] from linked [list] and [cache] map.
   @protected
   LruCacheEntry<K, V>? evictListEntry(LruCacheEntry<K, V> entry) =>
-      cache.remove(entry.key)?..unlink();
+    cache.remove(entry.key)?..unlink();
 
   // MapBase required methods
 
@@ -61,8 +65,18 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
 
   @override
   void operator []=(K key, V value) {
-    if (cache.containsKey(key)) {
-      remove(key);
+    if (cache[key] case final entry?) {
+      if (identical(entry.value, value)) {
+        // we're replacing key with the same value, so we need only to relink
+        // entry to the top of list
+        touchListEntry(entry);
+        return;
+      }
+      // we're replacing key, so we need first to remove existing entry from
+      // the list
+      final removed = remove(key);
+      assert(null != removed, 'Remove did not return entry, but key is supposedly present');
+      assert(identical(removed, entry.value), 'Removed unrelated entry');
     }
     final entry = cache[key] = LruCacheEntry(key, value);
     touchListEntry(entry);
@@ -85,7 +99,9 @@ base class LruCache<K, V extends Object> with MapBase<K, V> {
 
   @override
   bool containsValue(Object? value) {
-    for (final entry in cache.values) if (entry.value == value) return true;
+    for (final entry in cache.values)
+      if (entry.value == value)
+        return true;
     return false;
   }
 

--- a/test/lru_cache_test.dart
+++ b/test/lru_cache_test.dart
@@ -1,7 +1,6 @@
 import 'package:lru/lru.dart';
 import 'package:test/test.dart';
 
-
 bool get isDebugMode {
   var isDebug = false;
   assert(isDebug = true, 'always true in debug');
@@ -38,6 +37,37 @@ void main() {
       expect(cache[1], equals('uno'));
     });
 
+    test('should update value of existing key when cache is full', () {
+      final cache = LruCache<int, String>(2);
+      cache[1] = 'one';
+      cache[2] = 'two';
+      cache[1] = 'uno';
+
+      expect(cache[1], equals('uno'));
+      expect(cache[2], equals('two'));
+    });
+
+    test('should not evict any entries when updating', () {
+      final cache = LruCache<int, String>(2);
+      cache[1] = 'one';
+      expect(cache.length, equals(1));
+      cache[1] = 'uno';
+      expect(cache.length, equals(1));
+      cache[2] = 'two';
+      expect(cache.length, equals(2));
+      cache[2] = 'dos';
+      expect(cache.length, equals(2));
+    });
+
+    test('should evict when updating only if the cache is full', () {
+      const capacity = 3;
+      final cache = LruCache<String, int>(capacity);
+      for (var i = 0; i < capacity + 1; i++) {
+        cache['key'] = i;
+        expect(cache.length, equals(1));
+      }
+    });
+
     test('should not evict recently used item', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
@@ -50,7 +80,7 @@ void main() {
       expect(cache[3], equals('three'));
     });
 
-    test('should support manual key removal', () async {
+    test('should support manual key removal', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
       cache[2] = 'two';
@@ -60,7 +90,7 @@ void main() {
       expect(cache[2], isNull);
     });
 
-    test('should return null for non-existent key', () async {
+    test('should return null for non-existent key', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
       cache[2] = 'two';
@@ -70,14 +100,14 @@ void main() {
       expect(cache[3], isNull);
     });
 
-    test('should return correct size', () async {
+    test('should return correct size', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
 
       expect(cache.length, equals(1));
     });
 
-    test('should be able to clear all items', () async {
+    test('should be able to clear all items', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
       cache[2] = 'one';

--- a/test/lru_cache_test.dart
+++ b/test/lru_cache_test.dart
@@ -7,8 +7,24 @@ bool get isDebugMode {
   return isDebug;
 }
 
+class TestObject {
+  TestObject(this.value);
+
+  final String value;
+
+  @override
+  String toString() => value;
+}
+
+void expectLength<K, V extends Object>(LruCache<K, V> cache, dynamic matcher) {
+  expect(cache.length, matcher);
+  expect(cache.cache.length, matcher);
+  expect(cache.list.length, matcher);
+}
+
 void main() {
   group('LruCache', () {
+
     test('should add and retrieve values', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
@@ -50,21 +66,42 @@ void main() {
     test('should not evict any entries when updating', () {
       final cache = LruCache<int, String>(2);
       cache[1] = 'one';
-      expect(cache.length, equals(1));
       cache[1] = 'uno';
-      expect(cache.length, equals(1));
       cache[2] = 'two';
-      expect(cache.length, equals(2));
       cache[2] = 'dos';
-      expect(cache.length, equals(2));
+
+      expect(cache[1], equals('uno'));
+      expect(cache[2], equals('dos'));
     });
 
-    test('should evict when updating only if the cache is full', () {
+    test('updating same with the value should delay object eviction', () {
+      final cache = LruCache<int, TestObject>(2);
+      final one = TestObject('one');
+      final two = TestObject('two');
+      final three = TestObject('three');
+      cache[1] = one;
+      final oneEntry = cache.cache[1];
+      expect(oneEntry, isNotNull);
+      cache[2] = two;
+      cache[1] = one;
+      cache[3] = three;
+
+      // check that entry is preserved and not recreated
+      expect(cache.cache[1], equals(oneEntry));
+      expect(cache[1], equals(one));
+      expect(cache[2], isNull);
+      expect(cache[3], equals(three));
+    });
+
+    test('should maintain size when updating items', () {
+      // this test checks that list and map is in sync (same size)
+      // during update operation
       const capacity = 3;
       final cache = LruCache<String, int>(capacity);
+      expectLength(cache, equals(0));
       for (var i = 0; i < capacity + 1; i++) {
         cache['key'] = i;
-        expect(cache.length, equals(1));
+        expectLength(cache, equals(1));
       }
     });
 
@@ -101,10 +138,30 @@ void main() {
     });
 
     test('should return correct size', () {
-      final cache = LruCache<int, String>(2);
-      cache[1] = 'one';
+      // this test checks that list and map is in sync (same size)
+      // during multiple add and update operations
+      final cache = LruCache<int, TestObject>(2);
+      final one = TestObject('one');
+      final two = TestObject('two');
+      final three = TestObject('three');
+      final uno = TestObject('uno');
+      final dos = TestObject('dos');
 
-      expect(cache.length, equals(1));
+      expectLength(cache, equals(0));
+      cache[1] = one;
+      expectLength(cache, equals(1));
+      cache[2] = two;
+      expectLength(cache, equals(2));
+      cache[3] = three;
+      expectLength(cache, equals(2));
+      cache[1] = uno;
+      expectLength(cache, equals(2));
+      cache[2] = dos;
+      expectLength(cache, equals(2));
+      // special case: we must ensure that list doesn't grow if we replace
+      // object with the same value
+      cache[2] = dos;
+      expectLength(cache, equals(2));
     });
 
     test('should be able to clear all items', () {
@@ -113,7 +170,7 @@ void main() {
       cache[2] = 'one';
       cache.clear();
 
-      expect(cache.length, equals(0));
+      expectLength(cache, equals(0));
       expect(cache[1], isNull);
       expect(cache[2], isNull);
     });


### PR DESCRIPTION
## Summary

Fixes a bug where updating an existing key in LruCache caused an unintended eviction.

## Repro steps
	1.	Insert keys a and b into a cache of capacity 2.
	2.	Update key a.
	3.	Expected: a keeps new value, no eviction occurs.
	4.	Actual: an eviction happens incorrectly.

## Fix

Check for containsKey() and remove old entry before adding de replacement.
